### PR TITLE
Make MulticheckboxField getValue and setValue compatible. Fixes #25

### DIFF
--- a/Fields/MulticheckboxField.php
+++ b/Fields/MulticheckboxField.php
@@ -85,8 +85,14 @@ class MulticheckboxField extends Field
 
         $checked = array();
 
-        foreach ($values as $name => $one) {
-            $checked[$this->nameFor($name)] = true;
+        if ( $this->is_numeric_array( $values ) ) {
+		foreach ( $values as $name ) {
+			$checked[ $this->nameFor( $name ) ] = true;
+		}
+        } else {
+	        foreach ( $values as $name => $one ) {
+		        $checked[ $this->nameFor( $name ) ] = true;
+	        }
         }
 
         foreach ($this->checkboxes as $checkbox) {
@@ -96,6 +102,21 @@ class MulticheckboxField extends Field
                 $checkbox->setChecked(false);
             }
         }
+    }
+	
+    protected function is_numeric_array( $array ) {
+
+    	$i = 0;
+
+    	foreach ( $array as $key => $_ ) {
+    		if ( $i !== $key ) {
+    			return false;
+		    }
+
+		    $i++;
+	    }
+
+	    return true;
     }
 
     public function getValue()


### PR DESCRIPTION
Previously, `setValue` expected an array of options to `true`. However, `getValue` returns an array of options. The previous behavior is retained for compatibility with PHP `$_POST` and manual usage of `setValue`.