### PR TITLE
eol for php 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 5.4
-    # - 5.5 - Not sure why travis 5.5 version does not support imagettfbox()
     - 5.6
     - 7.0
     - 7.1

--- a/README.md
+++ b/README.md
@@ -444,3 +444,7 @@ to set the cache directory.
 ## License
 
 `Gregwar\Formidable` is under MIT License, have a look at the `LICENSE` file for more information.
+
+## History
+
+V2.0 End support for PHP <5.6

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.6",
         "ext-gd": "*",
         "gregwar/captcha": "1.1.*",
         "gregwar/cache": "1.0.*",


### PR DESCRIPTION
Eol for PHP 5.4.  Needs to be tagged at V2.0.0 as it is a BC break for users still using at at <5.6