### PR TITLE
Add Japanese translation

### DIFF
--- a/Language/Japanese.php
+++ b/Language/Japanese.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gregwar\Formidable\Language;
+
+class Japanese extends Language
+{
+    protected $messages = array(
+    'read_only' => '項目: %s は読み取り専用です。変更しないでください',
+        'value_required' => '項目: %s を入力してください',
+        'bad_format' => '項目: %s の入力形式が正しくありません',
+        'at_least' => '項目: %s は %d 文字以上の入力が必要です',
+        'not_more' => '項目: %s は %d 文字以下にしてください',
+        'bad_email' => '項目: %s に有効なメールアドレスを入力してください',
+        'bad_captcha' => 'CAPTCHA（キャプチャ）の入力が正しくありません',
+        'bad_date' => '日付: %s の入力が正しくありません',
+        'add' => '追加',
+        'remove' => '削除',
+        'file_size_too_big' => '項目: %s のファイルサイズを %s 以下にしてください',
+        'file_image' => '項目: %s は画像ファイルである必要があります',
+        'file_required' => '項目: %s にファイルを指定してください',
+        'integer' => '項目: %s には整数を入力してください',
+        'should_check' => '項目: %s にチェックを付けてください',
+        'number' => '項目: %s には数字を入力してください',
+        'number_min' => '項目: %s は %s 以上にしてください',
+        'number_max' => '項目: %s は %s 以下にしてください',
+        'number_step' => '項目: %s は %f の倍数にしてください',
+        'should_choose' => '項目: %s を選択してください',
+        'multiple_min' => '項目: %s には %d 個以上の入力が必要です',
+        'multiple_mmax' => '項目: %s の入力は %d 個以下にしてください',
+        'bad_array_value' => '項目群: %s の値が正しくありません',
+    );
+}


### PR DESCRIPTION
Hi. Thank you for a nice form library.
Its so developer-friendly, I like it.
I translated error messages into Japanese for one of my WordPress sites.
Please merge this if you like it.