### PR TITLE
issue49 Saving memory of which quote type is used in attribute value

### DIFF
--- a/Fields/Field.php
+++ b/Fields/Field.php
@@ -86,9 +86,9 @@ abstract class Field extends LanguageAware
     /**
      * Define an attribute
      */
-    public function setAttribute($name, $value)
+    public function setAttribute($name, $value, $quote = '"')
     {
-        $this->attributes[$name] = $value;
+        $this->attributes[$name] = ['value' => $value, 'quote' => $quote];
     }
 
     /**
@@ -122,7 +122,7 @@ abstract class Field extends LanguageAware
     /**
      * Function called by the dispatcher
      */
-    public function push($name, $value = null)
+    public function push($name, $value = null, $quote = '"')
     {
         switch ($name) {
         case 'name':
@@ -162,9 +162,9 @@ abstract class Field extends LanguageAware
         default:
             if (preg_match('#^([a-z0-9_-]+)$#mUsi', $name)) {
                 if (null !== $value) {
-                    $this->setAttribute($name, $value);
+                    $this->setAttribute($name, $value, $quote);
                 } else {
-                    $this->setAttribute($name, $name);
+                    $this->setAttribute($name, $name, $quote);
                 }
             }
         }
@@ -314,7 +314,8 @@ abstract class Field extends LanguageAware
         $html = '<input ';
 
         foreach ($this->attributes as $name => $value) {
-            $html.= $name.'="'.$value.'" ';
+            $quote = $value['quote'];
+            $html.= $name."={$quote}{$value['value']}{$quote} ";
         }
 
         if ($this->required) {
@@ -325,7 +326,8 @@ abstract class Field extends LanguageAware
         $html.= 'name="'.$this->getName().'" ';
 
         if (($value = $this->getValue()) !== null && gettype($value) != 'object') {
-            $html.= 'value="'.htmlspecialchars($value).'" ';
+            $quote = $value['quote'];
+            $html.= "value={$quote}".htmlspecialchars($value)."{$quote}";
         }
 
         $html.= '/>';

--- a/Fields/Option.php
+++ b/Fields/Option.php
@@ -71,7 +71,8 @@ class Option extends Field
     {
         $html = '<option ';
         foreach ($this->attributes as $name => $value) {
-            $html.= $name.'="'.$value.'" ';
+            $quote = $value['quote'];
+            $html.= $name."={$quote}{$value['value']}{$quote} ";
         }
         if ($selected) {
             $html.='selected="selected" ';

--- a/Fields/Select.php
+++ b/Fields/Select.php
@@ -24,7 +24,7 @@ class Select extends Field
      */
     protected $options = array();
 
-    public function push($name, $value = null)
+    public function push($name, $value = null, $quote = '"')
     {
         if ($name == 'multiple') {
             $this->multiple = true;
@@ -33,7 +33,7 @@ class Select extends Field
             $this->allowAdd = true;
         }
 
-        parent::push($name, $value);
+        parent::push($name, $value, $quote);
     }
 
     public function __sleep()
@@ -130,7 +130,8 @@ class Select extends Field
 
         $html = '<select name="'.$this->getName().$arr.'" ';
         foreach ($this->attributes as $name => $value) {
-            $html.= $name.'="'.$value.'" ';
+            $quote = $value['quote'];
+            $html .= $name."={$quote}{$value['value']}{$quote} ";
         }
         $html.= ">\n";
 

--- a/Parser.php
+++ b/Parser.php
@@ -118,7 +118,7 @@ class Parser extends ParserData
                                 }
 
                                 $this->push(new PostIndicator($name));
-                            } 
+                            }
 
                             $this->push('</form>');
                             break;
@@ -310,12 +310,15 @@ class Parser extends ParserData
                 $value = null;
             
                 if (isset($match[5])) {
+                    // Single quotes are being used
+                    $quote = "'";
                     $value = trim($match[5]);
                 } else if (isset($match[4])) {
+                    // Double quotes are being used
+                    $quote = '"';
                     $value = trim($match[4]);
                 }
-
-                $field->push($key, $value ? html_entity_decode($value) : $value);
+                $field->push($key, $value ? html_entity_decode($value) : $value, $quote);
             }, $data);
 
             return $field;


### PR DESCRIPTION
Something like this would allow the quote used in the original html, e.g.:
custom-attribute='valuewith"double"quotes'
to preserve its original value unmodified and to not terminate the string early by printing double quotes inside of double quotes.