### PR TITLE
Keep the "required" attribute on required <select> elements

### DIFF
--- a/Fields/Select.php
+++ b/Fields/Select.php
@@ -129,9 +129,15 @@ class Select extends Field
         }
 
         $html = '<select name="'.$this->getName().$arr.'" ';
+
         foreach ($this->attributes as $name => $value) {
             $html.= $name.'="'.$value.'" ';
         }
+
+        if ($this->required) {
+            $html.= 'required="required" ';
+        }
+
         $html.= ">\n";
 
         foreach ($this->options as $option) {

--- a/tests/FormTests.php
+++ b/tests/FormTests.php
@@ -117,6 +117,16 @@ class FormTests extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Testing that the emitted <select> HTML contains the required attribute
+     */
+    public function testSelectRequiredAttribute()
+    {
+        $form = $this->getForm('select-required.html');
+
+        $this->assertContains('required="required"', $form->getHtml());
+    }
+
+    /**
      * Testing that the CSRF token is t he same if computer twice on
      * the same file, and different for another file with a different form name
      */


### PR DESCRIPTION
Fixes #52 

Included a testcase in `FormTests.php` using an existing fixture (`select-required.html`), not sure if this is the best spot for it.