### PR TITLE
Keep the "required" attribute on required <textarea> elements

### DIFF
--- a/Fields/Textarea.php
+++ b/Fields/Textarea.php
@@ -27,6 +27,10 @@ class Textarea extends Field
             $html.= $name.'="'.$value.'" ';
         }
 
+        if ($this->required) {
+            $html.= 'required="required" ';
+        }
+
         $html.= '>';
         $html.= htmlspecialchars($this->value);
         $html.= '</textarea>'."\n";


### PR DESCRIPTION
Hi, the required attribute on <textarea> elements seems to work well during validation, but it is not emitted into the generated HTML.