### PR TITLE
Travis enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
-
-addons:
-    apt_packages:
-        - php*-gd
-        - libfreetype*
+    - 7.3
 
 script:
     - composer install

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.0",
     "gregwar/cache": "~1.0.9",
     "symfony/property-access": "~2.8.0"
   },


### PR DESCRIPTION
# Changed log
- Let PHP version requirement require `php-7.0` at least and changing PHP version definition on `composer.json`.
- Remove the additional packages during Travis CI build because they're defined on pre-built PHP versions on Travis CI environment.