### PR TITLE
Test enhancement

### DIFF
--- a/tests/ConstraintsTests.php
+++ b/tests/ConstraintsTests.php
@@ -3,11 +3,13 @@
 use Gregwar\Formidable\Form;
 use Gregwar\Formidable\Factory;
 use Gregwar\Formidable\PostIndicator;
+use Gregwar\Formidable\Fields\FileField;
+use PHPUnit\Framework\TestCase;
 
 /**
- * Special type "file" returning hash of the file instead of actually saving it 
+ * Special type "file" returning hash of the file instead of actually saving it
  */
-class FileField_NoSave extends \Gregwar\Formidable\Fields\FileField
+class FileField_NoSave extends FileField
 {
     public function save($filename)
     {
@@ -20,7 +22,7 @@ class FileField_NoSave extends \Gregwar\Formidable\Fields\FileField
  *
  * @author Grégoire Passault <g.passault@gmail.com>
  */
-class ConstraintsTests extends \PHPUnit\Framework\TestCase
+class ConstraintsTests extends TestCase
 {
     /**
      * Testing rendering a required field
@@ -68,7 +70,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
         $this->assertAccept($form, array(
             'name' => ''
         ));
- 
+
         $this->assertEquals('', $form->name);
 
         $this->assertAccept($form, array(
@@ -84,7 +86,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
     public function testMaxLength()
     {
         $form = $this->getForm('maxlength.html');
-        
+
         $this->assertContains('maxlength', "$form");
 
         $this->assertAccept($form, array(
@@ -102,7 +104,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
     public function testMinLength()
     {
         $form = $this->getForm('minlength.html');
-        
+
         $this->assertContains('minlength', "$form");
 
         $this->assertAccept($form, array(
@@ -291,7 +293,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
         $this->assertRefuse($form, array(
             'city' => 'xy'
         ));
-        
+
         $this->assertAccept($form, array(
             'city' => ''
         ));
@@ -307,7 +309,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
         $this->assertRefuse($form, array(
             'city' => 'xy'
         ));
-        
+
         $this->assertRefuse($form, array(
             'city' => ''
         ));
@@ -319,19 +321,19 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
     public function testSelectMultiple()
     {
         $form = $this->getForm('select-multiple.html');
-        
+
         $this->assertAccept($form, array(
             'city' => array('pa')
         ));
-        
+
         $this->assertAccept($form, array(
             'city' => array('pa', 'la')
         ));
-        
+
         $this->assertRefuse($form, array(
             'city' => 'pa'
         ));
-        
+
         $this->assertRefuse($form, array(
             'city' => array('xy')
         ));
@@ -391,7 +393,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
 
         $form->source('animals', array(
             '1' => 'Cat',
-            '2' => 'Dog', 
+            '2' => 'Dog',
             '3' => 'Zebra'
         ));
 
@@ -538,8 +540,8 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
             'animals' => array('1' => '1', '3' => '1')
         ));
 
-        $this->assertTrue(in_array('1', $form->animals));
-        $this->assertTrue(in_array('3', $form->animals));
+        $this->assertContains('1', $form->animals);
+        $this->assertContains('3', $form->animals);
 
         $this->assertContains('checked', "$form");
 
@@ -556,7 +558,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
     public function testMultiCheckBoxSetValue()
     {
         $form = $this->getForm('multicheckbox.html');
-        
+
         $form->source('animals', array(
             '1' => 'Cat',
             '2' => 'Dog',
@@ -565,7 +567,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
 
         $form->setValue('animals', array('2' => '1', '3' => '1'));
         $this->assertEquals(array('2', '3'), $form->getValue('animals'));
-        
+
         $form->setValue('animals', array('2', '3'));
         $this->assertEquals(array('2', '3'), $form->getValue('animals'));
     }
@@ -576,7 +578,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
     public function testFile()
     {
         $factory = new Factory;
-        $factory->registerType('file', '\FileField_NoSave');
+        $factory->registerType('file', \FileField_NoSave::class);
         $form = $factory->getForm(__DIR__.'/files/form/upload.html');
         $file = __DIR__.'/files/upload/test.txt';
         $hash = sha1(file_get_contents($file));
@@ -611,7 +613,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
     public function testMultipleFiles()
     {
         $factory = new Factory;
-        $factory->registerType('file', '\FileField_NoSave');
+        $factory->registerType('file', \FileField_NoSave::class);
         $form = $factory->getForm(__DIR__.'/files/form/multiple_file.html');
         $file = __DIR__.'/files/upload/test.txt';
 
@@ -633,7 +635,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
                 )
             )
         ));
-        
+
         $this->assertRefuse($form, array(), array(
             'files' => array(
                 0 => array(
@@ -748,17 +750,17 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
             array('first_name' => 'Bob', 'age' => '8'),
             array('first_name' => 'Jack', 'age' => '18'),
         )));
-        
+
         $this->assertAccept($form, array('book_name' => 'Test', 'authors' => array(
             array('first_name' => 'Bob', 'age' => '8'),
             array('first_name' => 'Jack', 'age' => '18'),
         )));
 
-       // The min-entries constraint 
+       // The min-entries constraint
         $this->assertRefuse($form, array('book_name' => 'Test', 'authors' => array(
             array('first_name' => 'Bob', 'age' => '8'),
         )));
-       
+
         // The min
         $this->assertRefuse($form, array('book_name' => 'Test', 'authors' => array(
             array('first_name' => 'Bob', 'age' => '3'),
@@ -781,7 +783,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
             array('first_name' => 'Bob', 'age' => '8'),
             array('first_name' => 'Jack', 'age' => '18'),
         )));
-        
+
         $this->assertRefuse($form, array('book_name' => 'Test', 'authors' => array(
             array('first_name' => 'Bob', 'age' => '8'),
             array('first_name' => 'Jack', 'age' => '18'),
@@ -793,16 +795,16 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
             array('first_name' => 'Jack', 'age' => '18'),
         )));
     }
-    
+
     /**
      * Testing bad type
-     
+
      * @expectedException               Gregwar\Formidable\ParserException
      * @expectedExceptionMessage        Unknown field type: name
      */
     public function testCheckBadType()
     {
-        $form = $this->getForm('bad_type.html');
+        $this->getForm('bad_type.html');
     }
 
     /**
@@ -812,18 +814,18 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
     {
         $form = $this->getForm('array.html');
 
-        $this->assertTrue(is_array($form->getValue('t')));
-        $this->assertEquals(2, count($form->getValue('t')));
+        $this->assertInternalType('array', $form->getValue('t'));
+        $this->assertCount(2, $form->getValue('t'));
 
         $values = $form->getValues();
-        $this->assertTrue(is_array($values['a']));
-        $this->assertTrue(is_array($values['a']['b']));
+        $this->assertInternalType('array', $values['a']);
+        $this->assertInternalType('array', $values['a']['b']);
         $this->assertEquals('testing', $values['a']['b']['c']);
         $this->assertEquals('testing2', $values['a']['b']['d']);
 
-        $this->assertTrue(is_array($values['x']));
-        $this->assertTrue(is_array($values['x']['y']));
-        $this->assertTrue(is_array($values['x']['y']['z']));
+        $this->assertInternalType('array', $values['x']);
+        $this->assertInternalType('array', $values['x']['y']);
+        $this->assertInternalType('array', $values['x']['y']['z']);
         $this->assertEquals('2', $values['x']['y']['z']['k']);
 
         $this->assertAccept($form, array(
@@ -955,7 +957,7 @@ class ConstraintsTests extends \PHPUnit\Framework\TestCase
         return new Form(__DIR__.'/files/form/'.$file);
     }
 
-    public function setup()
+    protected function setup()
     {
         $_SESSION = array();
     }

--- a/tests/FactoryTests.php
+++ b/tests/FactoryTests.php
@@ -1,13 +1,15 @@
 <?php
 
 use Gregwar\Formidable\Factory;
+use Gregwar\Formidable\Fields\TextField;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Testing Formidable factory
  *
  * @author Grégoire Passault <g.passault@gmail.com>
  */
-class FactoryTests extends \PHPUnit\Framework\TestCase
+class FactoryTests extends TestCase
 {
     /**
      * Testing creating forms using the factory
@@ -28,7 +30,7 @@ class FactoryTests extends \PHPUnit\Framework\TestCase
     public function testFactoryCustomType()
     {
         $factory = new Factory;
-        $factory->registerType('testing', '\Gregwar\Formidable\Fields\TextField');
+        $factory->registerType('testing', TextField::class);
 
         $form = $factory->getForm(__DIR__.'/files/factory/testing.html');
         $html = "$form";

--- a/tests/FormTests.php
+++ b/tests/FormTests.php
@@ -1,14 +1,16 @@
 <?php
 
+use Gregwar\Cache\Cache;
 use Gregwar\Formidable\Form;
 use Gregwar\Formidable\PostIndicator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Testing Formidable forms
  *
  * @author Grégoire Passault <g.passault@gmail.com>
  */
-class FormTests extends \PHPUnit\Framework\TestCase
+class FormTests extends TestCase
 {
     /**
      * Testing that toString() give the same thing as getHtml()
@@ -38,7 +40,7 @@ class FormTests extends \PHPUnit\Framework\TestCase
     public function testEnctype()
     {
         $form = $this->getForm('enctype_normal.html');
-        $this->assertFalse(strpos("$form", 'enctype='));
+        $this->assertNotContains('enctype=', "$form");
 
         $form = $this->getForm('enctype_file.html');
         $this->assertContains('enctype=', "$form");
@@ -176,7 +178,6 @@ class FormTests extends \PHPUnit\Framework\TestCase
      */
     public function testPostIndicator()
     {
-
         unset($_SESSION);
         $form1 = $this->getForm('post-indicator.html');
         $token1 = $form1->getToken();
@@ -275,7 +276,7 @@ class FormTests extends \PHPUnit\Framework\TestCase
     {
         $form = $this->getForm('quotes.html');
         $field = $form->getField('xxx');
-        
+
         $this->assertTrue($field->hasAttribute('foo'));
         $this->assertEquals($field->getAttribute('foo'), 'bar baz "bax"');
 
@@ -286,7 +287,6 @@ class FormTests extends \PHPUnit\Framework\TestCase
         $this->assertFalse($element == null);
         $this->assertTrue($element->hasAttribute('foo'));
         $this->assertEquals($element->getAttribute('foo'), 'bar baz "bax"');
-        
     }
 
     public function testPlaceholder()
@@ -314,7 +314,7 @@ class FormTests extends \PHPUnit\Framework\TestCase
      */
     public function testCache()
     {
-        $cache = new Gregwar\Cache\Cache;
+        $cache = new Cache;
         $cache->setCacheDirectory($this->getCacheDirectory());
 
         $form = $this->getForm('basic.html', null, $cache);
@@ -343,7 +343,7 @@ class FormTests extends \PHPUnit\Framework\TestCase
 
         preg_match_all('#option value="(.+)"#mUsi', $html, $matches);
 
-        $this->assertEquals(3, count($matches[1]));
+        $this->assertCount(3, $matches[1]);
         $this->assertEquals('X', $matches[1][0]);
         $this->assertEquals('A', $matches[1][1]);
         $this->assertEquals('B', $matches[1][2]);
@@ -354,7 +354,7 @@ class FormTests extends \PHPUnit\Framework\TestCase
         return new Form(__DIR__.'/files/form/'.$file, $vars, $cache);
     }
 
-    public function setup()
+    protected function setup()
     {
         $_SESSION = array();
     }
@@ -364,7 +364,7 @@ class FormTests extends \PHPUnit\Framework\TestCase
         return __DIR__ . '/cache';
     }
 
-    public function teardown()
+    protected function teardown()
     {
         $cacheDir = $this->getCacheDirectory();
         `rm -rf $cacheDir`;

--- a/tests/ParserTests.php
+++ b/tests/ParserTests.php
@@ -1,14 +1,23 @@
 <?php
 
 use Gregwar\Formidable\Parser;
-use Gregwar\Formidable\ParserException;
+use Gregwar\Formidable\Fields\TextField;
+use Gregwar\Formidable\Fields\EmailField;
+use Gregwar\Formidable\Fields\PasswordField;
+use Gregwar\Formidable\Fields\FileField;
+use Gregwar\Formidable\Fields\HiddenField;
+use Gregwar\Formidable\Fields\IntField;
+use Gregwar\Formidable\Fields\Select;
+use Gregwar\Formidable\Fields\Radios;
+use Gregwar\Formidable\Fields\Textarea;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Testing Formidable parser
  *
  * @author Grégoire Passault <g.passault@gmail.com>
  */
-class ParserTests extends \PHPUnit\Framework\TestCase
+class ParserTests extends TestCase
 {
     /**
      * Testing the returns of a basic parse
@@ -19,7 +28,7 @@ class ParserTests extends \PHPUnit\Framework\TestCase
 
         $fields = $parser->getFields();
 
-        $this->assertEquals(2, count($fields));
+        $this->assertCount(2, $fields);
         $this->assertArrayHasKey('foo', $fields);
         $this->assertArrayHasKey('foo2', $fields);
 
@@ -35,17 +44,17 @@ class ParserTests extends \PHPUnit\Framework\TestCase
 
         $fields = $parser->getFields();
 
-        $this->assertEquals(9, count($fields));
+        $this->assertCount(9, $fields);
 
-        $this->assertInstanceOf('Gregwar\Formidable\Fields\TextField', $fields['name']);
-        $this->assertInstanceOf('Gregwar\Formidable\Fields\EmailField', $fields['email']);
-        $this->assertInstanceOf('Gregwar\Formidable\Fields\PasswordField', $fields['pass']);
-        $this->assertInstanceOf('Gregwar\Formidable\Fields\FileField', $fields['picture']);
-        $this->assertInstanceOf('Gregwar\Formidable\Fields\HiddenField', $fields['cache']);
-        $this->assertInstanceOf('Gregwar\Formidable\Fields\IntField', $fields['age']);
-        $this->assertInstanceOf('Gregwar\Formidable\Fields\Select', $fields['choices']);
-        $this->assertInstanceOf('Gregwar\Formidable\Fields\Radios', $fields['radio']);
-        $this->assertInstanceOf('Gregwar\Formidable\Fields\Textarea', $fields['area']);
+        $this->assertInstanceOf(TextField::class, $fields['name']);
+        $this->assertInstanceOf(EmailField::class, $fields['email']);
+        $this->assertInstanceOf(PasswordField::class, $fields['pass']);
+        $this->assertInstanceOf(FileField::class, $fields['picture']);
+        $this->assertInstanceOf(HiddenField::class, $fields['cache']);
+        $this->assertInstanceOf(IntField::class, $fields['age']);
+        $this->assertInstanceOf(Select::class, $fields['choices']);
+        $this->assertInstanceOf(Radios::class, $fields['radio']);
+        $this->assertInstanceOf(Textarea::class, $fields['area']);
     }
 
     /**
@@ -130,7 +139,7 @@ class ParserTests extends \PHPUnit\Framework\TestCase
         $parser = $this->getParser('untyped_input.html');
         $fields = $parser->getFields();
 
-        $this->assertInstanceOf('Gregwar\Formidable\Fields\TextField', $fields['test']);
+        $this->assertInstanceOf(TextField::class, $fields['test']);
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,11 +1,5 @@
 <?php
 
-// backward compatibility
-if (!class_exists('\PHPUnit\Framework\TestCase') &&
-    class_exists('\PHPUnit_Framework_TestCase')) {
-    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
-}
-
 /**
  * Loading files to bootstrap testing
  *


### PR DESCRIPTION
# Changed log
- Using current assertions to assert the expected and result values.
- Removing additional white spaces.
- To be consistency, using the `use` syntax to declare required namespaces on the beginning of PHP file.
- Using the magic `::class` syntax to assert instance is expected.
- According to official [PHPUnit doc](https://phpunit.de/manual/6.5/en/fixtures.html), the `setUp` and `tearDown` fixture methods are `protected`, not `public`.