### PR TITLE
fix: test for value before htmlspecialchars

### DIFF
--- a/Fields/Textarea.php
+++ b/Fields/Textarea.php
@@ -32,7 +32,11 @@ class Textarea extends Field
         }
 
         $html.= '>';
-        $html.= htmlspecialchars($this->value);
+        
+        if ($this->value) {
+            $html.= htmlspecialchars($this->value);
+        }
+        
         $html.= '</textarea>'."\n";
 
         return $html;


### PR DESCRIPTION
In PHP >= 8.1 `htmlspecialchars` will throw a deprecation warning if passed a non-string value such as `null`. This is a common scenario for a textarea on a creation form.

This commit adds a check for the value to be truthy before sending it to `htmlspecialchars`, which should prevent the error without changing the current behaviour of the field.